### PR TITLE
Add unsigned config option to auth w/o aws creds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 import os
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+from pip._internal.req import parse_requirements
+from pip._internal.req.req_file import ParsedRequirement
 
 install_reqs = parse_requirements('requirements.txt', session=False)
 test_reqs = parse_requirements('requirements_test.txt', session=False)
 
-version = '0.6.1'
+version = '0.7.0'
 
 README="""Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
 
@@ -28,9 +29,9 @@ setup(
     packages=find_packages(),
     url='https://github.com/capless/warrant',
     license='Apache License 2.0',
-    install_requires=[str(ir.req) for ir in install_reqs],
+    install_requires=[str(x.requirement) for x in install_reqs],
     extras_require={
-        'test': [str(ir.req) for ir in test_reqs]
+        'test': [str(x.requirement) for x in test_reqs]
     },
     include_package_data=True,
     zip_safe=True,

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -1,5 +1,6 @@
 import ast
 import boto3
+import botocore
 import datetime
 import re
 import requests
@@ -168,6 +169,9 @@ class Cognito(object):
             boto3_client_kwargs['aws_secret_access_key'] = secret_key
         if user_pool_region:
             boto3_client_kwargs['region_name'] = user_pool_region
+
+        config = botocore.config.Config(signature_version=botocore.UNSIGNED)
+        boto3_client_kwargs['config'] = config
 
         self.client = boto3.client('cognito-idp', **boto3_client_kwargs)
 


### PR DESCRIPTION
* botocore requires the Config(signature_version=botocore.UNSIGNED)
  configuration option when declaring the client in order to allow for
  authentication without a local aws credential cache
* implemented in order to use warrant in a third party client
  application

Signed-off-by: Matt <matt@ultru.io>